### PR TITLE
Fix github workflows

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,6 +6,8 @@ name: CICD
 # Runs on push on the main branch, that actually occurs only after a pull request is accepted or a push to the main branch is made directly.
 on:
   push:
+    tags-ignore:
+      - '**'
 
 jobs:
   test:
@@ -35,6 +37,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     outputs:
       version: ${{ steps.semantic.outputs.version }}
+      released: ${{ steps.semantic.outputs.released }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,6 +51,7 @@ jobs:
           github_token: ${{ secrets.TOKEN }}
 
   deploy:
+    if: needs.release.outputs.released == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
fix #264 
Added tags-ignore to prevent CI/CD from triggering on tags. 
Runs deploy only when a new release is needed.